### PR TITLE
Tag feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Simple EC2 Snapshot
-===================
+EC2 Snapshot
+============
 
 Simple solution to backup ec2 instances using snapshots
 
@@ -16,9 +16,9 @@ With Simple EC2 Snapshot supports:
 
 ## Installation
 
-To install the tool, the simplest solution is to use pip:
+To install the tool, the est solution is to use pip:
 ```
-pip install simplec2snap
+pip install ec2snap
 ```
 
 ## Filters
@@ -27,17 +27,17 @@ You can first decide to choose what to backup with Instance ID or Tags. You can 
 
 For example, if I want to snapshot 2 instances in the same command line, it should looks like this:
 ```
-> ./simplec2snap.py -i i-ad0fcc4b -i i-56489db2
+> ./ec2snap.py -i i-ad0fcc4b -i i-56489db2
 ```
 
 To snapshot multiple instances by selecting multiple tags. Here is an example with 2 tagsi, so it should match both:
 ```
-> ./simplec2snap.py -t Name 'instance*' -t env prod
+> ./ec2snap.py -t Name 'instance*' -t env prod
 ```
 
 If you want to add an instance in addition of the previous tags:
 ```
-> ./simplec2snap.py -t Name 'instance*' -t env prod -i i-ad0fcc4b
+> ./ec2snap.py -t Name 'instance*' -t env prod -i i-ad0fcc4b
 ```
 
 ## Credentials file
@@ -60,7 +60,7 @@ The default one should be located in '~/.aws_cred'. You can override this with '
 
 Use the dry run mode (enabled by default) to see what actions will be performed when selecting a tag Name or an instance:
 ```
-> ./simplec2snap.py -t Name "instance-name*"
+> ./ec2snap.py -t Name "instance-name*"
 2015-01-26 17:05:25,954 [INFO] == Launching dry run mode ==
 2015-01-26 17:05:25,954 [INFO] Connecting to AWS
 2015-01-26 17:05:25,955 [INFO] Getting instances information
@@ -76,7 +76,7 @@ Use the dry run mode (enabled by default) to see what actions will be performed 
 
 If you're ok with the previous dry run, then add '-u' for run mode:
 ```
-> ./simplec2snap.py -t Name "instance-name*" -u
+> ./ec2snap.py -t Name "instance-name*" -u
 2015-01-26 17:06:19,163 [INFO] == Launching run mode ==
 2015-01-26 17:06:19,163 [INFO] Connecting to AWS
 2015-01-26 17:06:19,163 [INFO] Getting instances information
@@ -94,7 +94,7 @@ By default Hot mode is selected to perform snapshot without stopping instances. 
 
 To do so, you have to add '-H' option:
 ```
-> ./simplec2snap.py -t Name "instance-name*" -u -H
+> ./ec2snap.py -t Name "instance-name*" -u -H
 2015-01-26 17:07:10,281 [INFO] == Launching run mode ==
 2015-01-26 17:07:10,281 [INFO] Connecting to AWS
 2015-01-26 17:07:10,282 [INFO] Getting instances information
@@ -118,7 +118,7 @@ To do so, you have to add '-H' option:
 
 In auto-scaling groups, you normally have x time the same running intance. Snapshoting a huge number of time the same instance may not be very interesting. That's why you can limit the number of snapshot by using '-l' command followed by the number of desired snapshot. If I only want one:
 ```
-> ./simplec2snap.py -t Name "instance-name*" -l 1 
+> ./ec2snap.py -t Name "instance-name*" -l 1 
 2015-01-26 17:11:27,561 [INFO] == Launching dry run mode ==
 2015-01-26 17:11:27,561 [INFO] Connecting to AWS
 2015-01-26 17:11:27,562 [INFO] Getting instances information
@@ -134,7 +134,7 @@ In auto-scaling groups, you normally have x time the same running intance. Snaps
 Still for auto-scaling groups, your root device may not be required to snapshot. Generally because it may be builded from a configuration manager and you just don't care of it. So the goal is to remove it from the snapshot list, you can so use '-o' option:
 
 ```
-> ./simplec2snap.py -t Name "instance-name*" -o  
+> ./ec2snap.py -t Name "instance-name*" -o  
 2015-01-26 17:11:50,757 [INFO] == Launching dry run mode ==
 2015-01-26 17:11:50,757 [INFO] Connecting to AWS
 2015-01-26 17:11:50,758 [INFO] Getting instances information
@@ -159,7 +159,7 @@ So for example, if you want to keep snapshots for 3 weeks and delete the old one
 
 Here is a basic example where I want to delete snapshots older than 10 days:
 ```
-> ./simplec2snap.py -t Name "instance-name*" -n -g 10 d
+> ./ec2snap.py -t Name "instance-name*" -n -g 10 d
 2015-01-28 10:12:11,216 [INFO] == Launching dry run mode ==
 2015-01-28 10:12:11,217 [INFO] Connecting to AWS
 2015-01-28 10:12:11,217 [INFO] Getting instances information
@@ -173,7 +173,7 @@ Here is a basic example where I want to delete snapshots older than 10 days:
 
 Here -n is used to not make snapshots, only delete olds. But you can ask on the same line to make snapshots AND remove old ones:
 ```
-> ./simplec2snap.py -t Name "instance-name*" -g 10 m   
+> ./ec2snap.py -t Name "instance-name*" -g 10 m   
 2015-01-26 17:22:43,263 [INFO] == Launching dry run mode ==
 2015-01-26 17:22:43,263 [INFO] Connecting to AWS
 2015-01-26 17:22:43,264 [INFO] Getting instances information
@@ -193,7 +193,7 @@ Here -n is used to not make snapshots, only delete olds. But you can ask on the 
 
 Another solution to manage the retention of your snapshots is to specify how many snapshots you want to keep. For example, if I have 5 snapshots per device of an instance and want to keep the last 4 ones:
 ```
-> ./simplec2snap.py -t Name "instance-name*" -n -d 4
+> ./ec2snap.py -t Name "instance-name*" -n -d 4
 2015-01-28 10:14:02,713 [INFO] == Launching dry run mode ==
 2015-01-28 10:14:02,713 [INFO] Connecting to AWS
 2015-01-28 10:14:02,713 [INFO] Getting instances information
@@ -209,8 +209,8 @@ Another solution to manage the retention of your snapshots is to specify how man
 
 Here is the help with the complete list of options:
 ```
-> ./simplec2snap.py 
-usage: simplec2snap.py [-h] [-r REGION] [-k KEY_ID] [-a ACCESS_KEY]
+> ./ec2snap.py 
+usage: ec2snap.py [-h] [-r REGION] [-k KEY_ID] [-a ACCESS_KEY]
                        [-c CREDENTIALS] [-p CRED_PROFILE] [-i INSTANCE_ID]
                        [-t ARG ARG] [-u] [-l LIMIT] [-H] [-m COLDSNAP_TIMEOUT]
                        [-o] [-g ARG ARG] [-d KEEP_LAST_SNAPSHOTS] [-n]

--- a/ec2snap/ec2snap
+++ b/ec2snap/ec2snap
@@ -6,6 +6,7 @@
 #
 # Contributors:
 #   Hugo Rosnet <hugo.rosnet@enovance.com>
+#   Julien Syx  <julien.syx@gmail.com>
 #
 # Dependencies:
 # - python boto
@@ -23,7 +24,7 @@ import datetime
 import logging
 from collections import OrderedDict
 
-__version__ = 'v0.4'
+__version__ = 'v0.5.1'
 
 LVL = {'INFO': logging.INFO,
        'DEBUG': logging.DEBUG,

--- a/ec2snap/ec2snap
+++ b/ec2snap/ec2snap
@@ -128,7 +128,7 @@ class ManageSnapshot:
     """
 
     def __init__(self, region, key_id, access_key, instance_list, tags,
-                 dry_run, timeout, cold_snap, limit, no_root_device,
+                 dry_run, timeout, cold_snap, limit, no_root_device, add_tags,
                  max_age, no_snap, keep_last_snapshots, logger=__name__):
         """
         :param region: EC2 region
@@ -180,6 +180,10 @@ class ManageSnapshot:
         self._access_key = access_key
         self._instance_list = instance_list
         self._tags = tags
+        # receive ["key1:value1", "key2:value2"], transform it to: {key1: value1, key2: value2}
+        self._add_tags = {}
+        if len(add_tags) > 0:
+            self._add_tags = {elem.split(':')[0]: elem.split(':')[1] for elem in add_tags[0]}
         self._dry_run = dry_run
         self._timeout = timeout
         self._cold_snap = cold_snap
@@ -353,10 +357,12 @@ class ManageSnapshot:
             if self._dry_run is False:
                 try:
                     snap_id = self._conn.create_snapshot(vol, snap_name)
-                    snap_id.add_tags({'type': stype,
-                                      'volume': vol,
-                                      'device': device,
-                                      'instance name': iid.name})
+                    tags_objects = self._conn.get_all_tags(filters={'resource_id': vol})
+                    current_tags = {tag.name: tag.value for tag in tags_objects}
+                    if bool(current_tags) is False:
+                        current_tags = {'type': stype, 'volume': vol, 'device': device, 'instance name': iid.name}
+                    tag_list = dict(current_tags, **self._add_tags)
+                    snap_id.add_tags(tag_list)
                 except Exception as e:
                     self.logger.critical("%s snapshot failed for %s(%s) [%s]" %
                                          (stype, vol, device, e))
@@ -576,6 +582,9 @@ def main():
     parser.add_argument('-t', '--tags', action='append', type=str,
                         default=[], metavar='ARG', nargs=2,
                         help='Select tags with values (ex: tagname value)')
+    parser.add_argument('-e', '--add_tags', action='append', type=str,
+                        default=[], metavar='ARG', nargs='*',
+                        help='Tags added to snapshots (ex: tag1:value1 ...')
 
     parser.add_argument('-u', '--dry_run', action='store_false', default=True,
                         help='Define if it should make snapshot or just \
@@ -647,6 +656,12 @@ def main():
             print("Don't have permission to read credentials file")
             sys.exit(1)
 
+    if arg.add_tags is not None and len(arg.add_tags) > 0:
+        for elem in arg.add_tags[0]:
+            if elem.find(':') == -1:
+                print("Tag '%s' has wrong format, missing separator ':'" % elem)
+                sys.exit(1)
+
     # Exit if no instance or tag has been set
     if arg.instance is None and arg.tags is None:
         print('Please set at least instance ID or tag with value')
@@ -657,8 +672,8 @@ def main():
                                             arg.access_key, arg.instance,
                                             arg.tags, arg.dry_run, arg.timeout,
                                             arg.cold_snap, arg.limit,
-                                            arg.no_root_device, arg.max_age,
-                                            arg.no_snap,
+                                            arg.no_root_device, arg.add_tags,
+                                            arg.max_age, arg.no_snap,
                                             arg.keep_last_snapshots)
         # Calculate max snapshot age
         if len(arg.max_age) > 0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[files]
+packages =
+    ec2snap
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,59 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
-from simplec2snap import __version__
+from setuptools import setup
+import re
+import os
+
+def get_version(package):
+    """
+    Return package version as listed in `__version__` in `init.py`.
+    """
+    init_py = open(os.path.join(package, 'ec2snap')).read()
+    return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
+
+
+def get_packages(package):
+    """
+    Return root package and all sub-packages.
+    """
+    return [dirpath
+            for dirpath, dirnames, filenames in os.walk(package)
+            if os.path.exists(os.path.join(dirpath, '__init__.py'))]
+
+
+def get_package_data(package):
+    """
+    Return all files under the root package, that are not in a
+    package themselves.
+    """
+    walk = [(dirpath.replace(package + os.sep, '', 1), filenames)
+            for dirpath, dirnames, filenames in os.walk(package)
+            if not os.path.exists(os.path.join(dirpath, '__init__.py'))]
+
+    filepaths = []
+    for base, filenames in walk:
+        filepaths.extend([os.path.join(base, filename)
+                          for filename in filenames])
+    return {package: filepaths}
+
+
+version = get_version('ec2snap')
 
 setup(
-    name='simplec2snap',
-    version=__version__,
-    packages=find_packages(),
+    name='ec2snap',
+    version=version,
+    packages=get_packages('ec2snap'),
+    package_data=get_package_data('ec2snap'),
+    scripts=['ec2snap/ec2snap'],
     author="Pierre Mavro",
     author_email="deimos@deimos.fr",
     description="Simple solution to backup ec2 instances using snapshots",
-    long_description=open('README.md').read(),
-    install_requires=open('requirements.txt').read().splitlines(),
+    install_requires=[
+        'boto>=2.34.0'
+    ],
     include_package_data=True,
-    url='https://github.com/enovance/simple_ec2_snapshot',
+    url='https://github.com/enovance/ec2_snapshot',
     classifiers=[
         "Programming Language :: Python",
         "Development Status :: 5 - Production/Stable",
@@ -24,5 +63,5 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
         "Topic :: Communications",
-    ],
+    ]
 )


### PR DESCRIPTION
Before the commit only the following tags were set:
{'type': stype, 'volume': vol, 'device': device, 'instance name': iid.name}

Now the snapshot will reuse existing tags of the volumes if it has any, otherwise it will use the previously established ones.
You can also add some more tags with the -e parameter, by providing arguments as such:
-e "tag1:value1" "tag2:value2" etc